### PR TITLE
[Client] File browser for Focus tab

### DIFF
--- a/client/src/components/FileBrowser.vue
+++ b/client/src/components/FileBrowser.vue
@@ -31,7 +31,9 @@
             mdi-file
           </template>
         </v-icon>
-        {{ item.path }}
+        <span class="text-truncate">
+          {{ item.path }}
+        </span>
         <v-spacer />
 
         <v-list-item-action v-if="!item.isFolder">

--- a/client/src/components/FileBrowser.vue
+++ b/client/src/components/FileBrowser.vue
@@ -1,0 +1,153 @@
+<template>
+  <v-card
+    height="100%"
+    outlined
+  >
+    <v-card-title>
+      <router-link
+        :to="{ name: 'focus', query: { location: rootDirectory } }"
+        style="text-decoration: none;"
+        class="mx-2"
+      >
+        {{ '.' }}
+      </router-link>
+      <template v-for="(part, i) in splitLocation">
+        /
+        <template v-if="part">
+          <router-link
+            :key="part"
+            :to="{ name: 'focus', query: { location: locationSlice(i) } }"
+            style="text-decoration: none;"
+            class="mx-2"
+          >
+            {{ part }}
+          </router-link>
+        </template>
+      </template>
+    </v-card-title>
+    <v-progress-linear
+      v-if="updating"
+      indeterminate
+    />
+    <v-divider v-else />
+    <v-list>
+      <v-list-item
+        v-for="item in items"
+        :key="item.path"
+        color="primary"
+        @click="selectPath(item)"
+      >
+        <v-icon
+          class="mr-2"
+          color="primary"
+        >
+          <template v-if="item.isFolder">
+            mdi-folder
+          </template>
+          <template v-else>
+            mdi-file
+          </template>
+        </v-icon>
+        {{ item.path }}
+        <v-spacer />
+
+        <v-list-item-action v-if="!item.isFolder">
+          <v-btn
+            icon
+            :href="item.file"
+          >
+            <v-icon color="primary">
+              mdi-download
+            </v-icon>
+          </v-btn>
+        </v-list-item-action>
+      </v-list-item>
+    </v-list>
+  </v-card>
+</template>
+
+<script lang="ts">
+import {
+  computed, defineComponent, Ref, ref, watch,
+} from '@vue/composition-api';
+import { axiosInstance } from '@/api';
+import { RawLocation } from 'vue-router';
+import { ChecksumFile } from '@/types';
+
+const parentDirectory = '..';
+const rootDirectory = '';
+
+interface FileItem extends ChecksumFile {
+  isFolder: boolean;
+  path: string;
+}
+
+export default defineComponent({
+  name: 'FileBrowser',
+  setup(props, ctx) {
+    const location = ref(rootDirectory);
+    const items: Ref<FileItem[]> = ref([]);
+    const updating = ref(false);
+
+    const splitLocation = computed(() => location.value.split('/'));
+
+    watch(location, async () => {
+      updating.value = true;
+
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      const { data } = await axiosInstance.get('/rgd/checksum_file/tree', { params: { path_prefix: location.value } });
+
+      items.value = [
+        ...location.value !== rootDirectory ? [{ path: parentDirectory, isFolder: true }] : [],
+        ...[
+          ...Object.keys(data.files).map((name: string) => (
+            { isFolder: false, path: name, ...data.files[name] }
+          )),
+          ...Object.keys(data.folders).map((name: string) => (
+            { isFolder: true, path: `${name}/`, ...data.files[name] }
+          )),
+        ],
+      ];
+      updating.value = false;
+    }, { immediate: true });
+
+    watch(location, () => {
+      const { location: existingLocation } = ctx.root.$route.query;
+
+      const route = {
+        ...ctx.root.$route,
+        query: { location: location.value },
+      } as RawLocation;
+
+      // Update route when location changes
+      if (existingLocation === location.value) { return; }
+      ctx.root.$router.push(route);
+    });
+
+    function locationSlice(index: number) {
+      return `${splitLocation.value.slice(0, index + 1).join('/')}/`;
+    }
+
+    function selectPath(item: FileItem) {
+      const { path, isFolder } = item;
+
+      if (!isFolder) { return; }
+      if (path === parentDirectory) {
+        const slicedLocation = location.value.split('/').slice(0, -2);
+        location.value = slicedLocation.length ? `${slicedLocation.join('/')}/` : '';
+      } else {
+        location.value = `${location.value}${path}`;
+      }
+    }
+
+    return {
+      items,
+      splitLocation,
+      updating,
+      rootDirectory,
+      locationSlice,
+      selectPath,
+    };
+  },
+});
+</script>

--- a/client/src/components/FileBrowser.vue
+++ b/client/src/components/FileBrowser.vue
@@ -4,25 +4,8 @@
     outlined
   >
     <v-card-title>
-      <router-link
-        :to="{ name: 'focus', query: { location: rootDirectory } }"
-        style="text-decoration: none;"
-        class="mx-2"
-      >
-        {{ '.' }}
-      </router-link>
-      <template v-for="(part, i) in splitLocation">
-        /
-        <template v-if="part">
-          <router-link
-            :key="part"
-            :to="{ name: 'focus', query: { location: locationSlice(i) } }"
-            style="text-decoration: none;"
-            class="mx-2"
-          >
-            {{ part }}
-          </router-link>
-        </template>
+      <template v-for="part in splitLocation">
+        /{{ part }}
       </template>
     </v-card-title>
     <v-progress-linear

--- a/client/src/router/index.ts
+++ b/client/src/router/index.ts
@@ -13,11 +13,13 @@ const routes: Array<RouteConfig> = [
     props: true,
   },
   {
+    name: 'tasks',
     path: '/tasks',
     component: AlgorithmView,
     props: true,
   },
   {
+    name: 'focus',
     path: '/focus',
     component: Focus,
     props: true,

--- a/client/src/views/Focus.vue
+++ b/client/src/views/Focus.vue
@@ -3,10 +3,10 @@
     style="height: 100%"
     no-gutters
   >
-    <v-col cols="2">
+    <v-col cols="3">
       <file-browser />
     </v-col>
-    <v-col cols="10">
+    <v-col cols="9">
       <!-- TODO: put iframe to RGD server-rendered pages here -->
     </v-col>
   </v-row>

--- a/client/src/views/Focus.vue
+++ b/client/src/views/Focus.vue
@@ -1,15 +1,33 @@
 <template>
-  <div>
-    TODO: Focus Tab
-  </div>
+  <v-row
+    style="height: 100%"
+    no-gutters
+  >
+    <v-col cols="2">
+      <file-browser />
+    </v-col>
+    <v-col cols="10">
+      <!-- TODO: put iframe to RGD server-rendered pages here -->
+    </v-col>
+  </v-row>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent } from '@vue/composition-api';
+import FileBrowser from '@/components/FileBrowser.vue';
 
 export default defineComponent({
-  setup() {
-
+  name: 'Focus',
+  components: { FileBrowser },
+  props: {
+    datasetId: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    return {
+    };
   },
 });
 </script>

--- a/client/src/views/Focus.vue
+++ b/client/src/views/Focus.vue
@@ -20,12 +20,12 @@ export default defineComponent({
   name: 'Focus',
   components: { FileBrowser },
   props: {
-    datasetId: {
-      type: String,
-      required: true,
-    },
+    // datasetId: {
+    //   type: String,
+    //   required: true,
+    // },
   },
-  setup(props) {
+  setup() {
     return {
     };
   },


### PR DESCRIPTION
![Peek 2022-01-03 20-14](https://user-images.githubusercontent.com/37340715/147997012-7dcfe16d-c962-49e8-b515-058a98a22e1a.gif)

Right now it shows every file in the database without regard for what `Dataset` each belongs to. Future work would be to extend the `/tree` endpoint to allow filtering by dataset by either overriding the endpoint here or implementing something upstream in `django-rgd`.

File browser code is based on https://github.com/dandi/dandiarchive/blob/master/src/views/FileBrowserView/FileBrowser.vue.