### PR TITLE
View raster and mesh files from the Danesfield workflow

### DIFF
--- a/client/src/components/FileBrowser.vue
+++ b/client/src/components/FileBrowser.vue
@@ -44,13 +44,27 @@
         </span>
         <v-spacer />
 
-        <v-list-item-action v-if="!item.isFolder">
+        <v-list-item-action
+          v-if="!item.isFolder"
+          class="d-inline-block"
+        >
           <v-btn
             icon
             :href="item.file"
           >
             <v-icon color="primary">
               mdi-download
+            </v-icon>
+          </v-btn>
+          <v-btn
+            icon
+            @click="setFile(item)"
+          >
+            <v-icon
+              v-if="openFile === item.name"
+              color="success"
+            >
+              mdi-eye
             </v-icon>
           </v-btn>
         </v-list-item-action>
@@ -64,6 +78,7 @@ import {
   computed, defineComponent, Ref, ref, watch,
 } from '@vue/composition-api';
 import { axiosInstance } from '@/api';
+import { openFile, setOpenFile } from '@/store';
 import { RawLocation } from 'vue-router';
 import { ChecksumFile } from '@/types';
 
@@ -130,8 +145,9 @@ export default defineComponent({
     function selectPath(item: FileItem) {
       const { path, isFolder } = item;
 
-      if (!isFolder) { return; }
-      if (path === parentDirectory) {
+      if (!isFolder) {
+        setOpenFile(item.name);
+      } else if (path === parentDirectory) {
         const slicedLocation = location.value.split('/').slice(0, -2);
         location.value = slicedLocation.length ? `${slicedLocation.join('/')}/` : '';
       } else {
@@ -151,6 +167,8 @@ export default defineComponent({
       locationSlice,
       selectPath,
       exitDataset,
+      openFile,
+      setOpenFile,
     };
   },
 });

--- a/client/src/components/FileBrowser.vue
+++ b/client/src/components/FileBrowser.vue
@@ -58,7 +58,7 @@
           </v-btn>
           <v-btn
             icon
-            @click="setFile(item)"
+            @click="setOpenFile(item)"
           >
             <v-icon
               v-if="openFile === item.name"

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,0 +1,8 @@
+import { ref } from '@vue/composition-api';
+
+// eslint-disable-next-line import/prefer-default-export
+export const openFile = ref('');
+
+export function setOpenFile(newFile: string) {
+  openFile.value = newFile;
+}

--- a/client/src/views/Explore.vue
+++ b/client/src/views/Explore.vue
@@ -10,14 +10,27 @@
       />
       <dataset-list v-else />
     </v-col>
-    <v-col cols="9">
-      <!-- TODO: put iframe to RGD server-rendered pages here -->
+    <v-col
+      cols="9"
+      class="d-flex justify-center align-center"
+    >
+      <iframe
+        v-if="iframeSrc"
+        :src="iframeSrc"
+        height="100%"
+        width="100%"
+      />
+      <template v-else>
+        Select a file to view.
+      </template>
     </v-col>
   </v-row>
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { computed, defineComponent, watch } from '@vue/composition-api';
+import { axiosInstance } from '@/api';
+import { openFile, setOpenFile } from '@/store';
 import DatasetList from '@/components/DatasetList.vue';
 import FileBrowser from '@/components/FileBrowser.vue';
 
@@ -30,8 +43,14 @@ export default defineComponent({
       required: false,
     },
   },
-  setup() {
+  setup(props) {
+    const iframeSrc = computed(() => (openFile.value ? `${axiosInstance.defaults.baseURL}datasets/${props.datasetId}/viewer/${openFile.value}` : undefined));
+
+    // Unset open file if the user navigates to a different URL
+    watch(() => props.datasetId, () => setOpenFile(''));
+
     return {
+      iframeSrc,
     };
   },
 });

--- a/danesfield/core/tasks/__init__.py
+++ b/danesfield/core/tasks/__init__.py
@@ -15,7 +15,7 @@ from rdoasis.algorithms.tasks.docker import _run_algorithm_task_docker
 import requests
 from rgd.models.common import ChecksumFile
 from rgd_3d.models import Mesh3D
-from rgd_imagery.models.base import Image, ImageSet
+from rgd_imagery.models import Image, ImageSet, Raster
 
 from danesfield.core.utils import danesfield_algorithm
 
@@ -40,7 +40,11 @@ def _ingest_checksum_files(files: List[ChecksumFile]):
             meshes.append(Mesh3D(file=checksum_file))
 
     if images:
-        ImageSet.objects.create().images.set(Image.objects.bulk_create(images))
+        images = Image.objects.bulk_create(images)
+        for image in images:
+            image_set = ImageSet.objects.create(name=image.file.name)
+            image_set.images.set([image])
+            Raster.objects.create(name=image.file.name, image_set=image_set)
 
     if meshes:
         Mesh3D.objects.bulk_create(meshes)

--- a/danesfield/core/views/__init__.py
+++ b/danesfield/core/views/__init__.py
@@ -11,6 +11,8 @@ from rest_framework.viewsets import ViewSet
 from danesfield.core.tasks import run_danesfield
 from danesfield.core.utils import danesfield_algorithm
 
+from .dataset import DatasetViewSet
+
 
 class DanesfieldAlgorithmViewSet(ViewSet):
     @swagger_auto_schema(method='GET')
@@ -29,3 +31,6 @@ class DanesfieldAlgorithmViewSet(ViewSet):
 
         task = run_danesfield(serializer.validated_data['input_dataset'])
         return Response(AlgorithmTaskSerializer(task).data)
+
+
+__all__ = ['DanesfieldAlgorithmViewSet', 'DatasetViewSet']

--- a/danesfield/core/views/dataset.py
+++ b/danesfield/core/views/dataset.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from django.http.response import HttpResponseNotFound, HttpResponseRedirect
 from django.urls import reverse
 from rdoasis.algorithms.models import Dataset

--- a/danesfield/core/views/dataset.py
+++ b/danesfield/core/views/dataset.py
@@ -9,8 +9,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.request import Request
 from rgd.models import ChecksumFile
 from rgd_3d.models import Mesh3D
-from rgd_imagery.models import Image, Raster
-from rgd_imagery.models.raster import RasterMeta
+from rgd_imagery.models import Image, RasterMeta
 
 
 class DatasetViewSet(BaseDatasetViewSet):
@@ -25,7 +24,7 @@ class DatasetViewSet(BaseDatasetViewSet):
 
                 # Display the associated Raster if this is an Image
                 if model == Image:
-                    ingested_file: Raster = ingested_file.imageset_set.first().raster
+                    ingested_file: RasterMeta = ingested_file.imageset_set.first().raster.rastermeta
                     model = RasterMeta
 
                 return HttpResponseRedirect(

--- a/danesfield/core/views/dataset.py
+++ b/danesfield/core/views/dataset.py
@@ -1,0 +1,37 @@
+from typing import Union
+
+from django.http.response import HttpResponseNotFound, HttpResponseRedirect
+from django.urls import reverse
+from rdoasis.algorithms.models import Dataset
+from rdoasis.algorithms.views.algorithms import DatasetViewSet as BaseDatasetViewSet
+from rest_framework.decorators import action
+from rest_framework.generics import get_object_or_404
+from rest_framework.request import Request
+from rgd.models import ChecksumFile
+from rgd_3d.models import Mesh3D
+from rgd_imagery.models import Image, Raster
+from rgd_imagery.models.raster import RasterMeta
+
+
+class DatasetViewSet(BaseDatasetViewSet):
+    @action(detail=True, methods=['GET'], url_path='viewer/(?P<path>.+)')
+    def viewer(self, request: Request, pk: str, path: str):
+        """Redirects to the appropriate viewer for the given file."""
+        dataset: Dataset = get_object_or_404(Dataset, pk=pk)
+        checksum_file: ChecksumFile = get_object_or_404(dataset.files, name=path)
+        for model in [Image, Mesh3D]:
+            try:
+                ingested_file = model.objects.get(file=checksum_file)
+
+                # Display the associated Raster if this is an Image
+                if model == Image:
+                    ingested_file: Raster = ingested_file.imageset_set.first().raster
+                    model = RasterMeta
+
+                return HttpResponseRedirect(
+                    reverse(model.detail_view_name, kwargs={'pk': ingested_file.pk})
+                )
+            except model.DoesNotExist:
+                pass
+
+        return HttpResponseNotFound()

--- a/danesfield/urls.py
+++ b/danesfield/urls.py
@@ -3,11 +3,11 @@ from django.contrib import admin
 from django.urls import include, path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
-from rdoasis.algorithms.views.algorithms import AlgorithmTaskViewSet, DatasetViewSet
+from rdoasis.algorithms.views.algorithms import AlgorithmTaskViewSet
 from rest_framework import permissions
 from rest_framework_extensions.routers import ExtendedSimpleRouter
 
-from danesfield.core.views import DanesfieldAlgorithmViewSet
+from danesfield.core.views import DanesfieldAlgorithmViewSet, DatasetViewSet
 
 # OpenAPI generation
 schema_view = get_schema_view(

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ setup(
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',
-        'django-rgd[configuration]>=0.2.10',
-        'django-rgd-3d>=0.2.10',
-        'django-rgd-imagery>=0.2.10',
+        'django-rgd @ git+https://github.com/ResonantGeoData/ResonantGeoData@3d-tiles-support#subdirectory=django-rgd',  # noqa
+        'django-rgd-3d @ git+https://github.com/ResonantGeoData/ResonantGeoData@3d-tiles-support#subdirectory=django-rgd-3d',  # noqa
+        'django-rgd-imagery @ git+https://github.com/ResonantGeoData/ResonantGeoData@3d-tiles-support#subdirectory=django-rgd-imagery',  # noqa
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',


### PR DESCRIPTION
We need a way to associate `Image`, `Mesh3D`, and `Tiles3D` objects generated from a `Dataset`'s output files with the `Dataset` itself.

@AlmightyYakob do you think this would be appropriate to upstream to OASIS? Then, we wouldn't need a separate model and could instead just put these `ManyToManyFields` directly on the `Dataset` model. I'm not certain that this would be in scope for OASIS though.