### PR TITLE
Change `master` to `main` in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 0 * * *"
 jobs:


### PR DESCRIPTION
CI isn't running on push to `main` because the Github actions workflow incorrectly specifies `master` as the default branch.