### PR TITLE
CI: Pin minio docker image and bump RD-OASIS dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
           - 5672:5672
       minio:
         # This image does not require any command arguments (which GitHub Actions don't support)
-        image: bitnami/minio:latest
+        # TODO: Unpin this when the latest bitnami/minio works again
+        image: bitnami/minio:2022.3.3
         env:
           MINIO_ACCESS_KEY: minioAccessKey
           MINIO_SECRET_KEY: minioSecretKey

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         # TEMP: Remove once fixed in upstream django-rgd
         'psutil',
         # Install with git
-        'RD-OASIS @ git+https://github.com/ResonantGeoData/RD-OASIS@d0d87837d09f2ea61ceed760c83848135dc8fdf9',  # noqa
+        'RD-OASIS @ git+https://github.com/ResonantGeoData/RD-OASIS@531959cebf659070827d4c11c8a9f0e1db772470',  # noqa
     ],
     dependency_links=['https://girder.github.io/large_image_wheels'],
     extras_require={


### PR DESCRIPTION
The latest bitnami/minio image doesn't work properly with our CI tests. This PR pins it to the most recent known working version.