### PR TITLE
Update dependencies + add RGD dependabot workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,17 @@
+name: RGD Dependabot
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  check-rgd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: marcoroth/dependabot-bump-together-action@main
+        with:
+          dependencies: django-rgd, django-rgd-3d, django-rgd-fmv, django-rgd-geometry, django-rgd-imagery
+          package_managers: pip
+          directory: /
+          branch: main
+          username: x-access-token
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'celery',
-        'django>=3.2',
+        'django>=4',
         'django-allauth',
         'django-click',
         'django-configurations[database,email]',
@@ -45,14 +45,14 @@ setup(
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',
-        'django-rgd[configuration]>=0.2.18',
-        'django-rgd-3d>=0.2.18',
-        'django-rgd-imagery>=0.2.18',
+        'django-rgd[configuration]==0.3.3',
+        'django-rgd-3d==0.3.3',
+        'django-rgd-imagery==0.3.3',
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',
         # Production-only
-        'django-composed-configuration[prod]>=0.19.2',
+        'django-composed-configuration[prod]>=0.21.0',
         'django-s3-file-field[boto3]',
         'gunicorn',
         # TEMP: Remove once fixed in upstream django-rgd
@@ -63,7 +63,7 @@ setup(
     dependency_links=['https://girder.github.io/large_image_wheels'],
     extras_require={
         'dev': [
-            'django-composed-configuration[dev]>=0.19.2',
+            'django-composed-configuration[dev]>=0.21.0',
             'django-debug-toolbar',
             'django-s3-file-field[minio]',
             'ipython',


### PR DESCRIPTION
We're not pinning the version of RGD we're using currently. Because of this, the recent upstream changes to the rgd_imagery REST API broke some of the API calls in the Vue client. In light of this, I think we should start pinning RGD and using Bane's RGD dependabot workflow to manage updates explicitly.

As part of updating to the latest version of RGD, I've also updated to Django 4 and the latest `django-composed-configuration`.