### PR TITLE
Render footprints and flight paths from FMV datasets with CesiumJS

### DIFF
--- a/client/src/components/CesiumViewer.vue
+++ b/client/src/components/CesiumViewer.vue
@@ -6,17 +6,8 @@ import {
   PropType,
   ref,
 } from '@vue/composition-api';
-import router from '@/router';
 import { cesiumViewer } from '@/store/cesium';
-import {
-  Primitive,
-  Entity,
-  Cartesian2,
-  ScreenSpaceEventType,
-  Camera,
-  ScreenSpaceEventHandler,
-  Viewer,
-} from 'cesium';
+import { Camera, Viewer } from 'cesium';
 import { imageryViewModels } from '@/utils/cesium';
 import { Polygon } from 'geojson';  // eslint-disable-line
 
@@ -39,7 +30,8 @@ export default defineComponent({
         imageryProviderViewModels: imageryViewModels,
         selectedImageryProviderViewModel: imageryViewModels[5], // Voyager
         animation: false,
-        timeline: false,
+        shouldAnimate: true,
+        timeline: true,
         infoBox: false,
         homeButton: false,
         fullscreenButton: false,
@@ -51,15 +43,6 @@ export default defineComponent({
 
       cesiumViewer.value.forceResize();
       Camera.DEFAULT_VIEW_FACTOR = 0;
-
-      const handler = new ScreenSpaceEventHandler(cesiumViewer.value.scene.canvas);
-      handler.setInputAction((movement: {position: Cartesian2}) => {
-        const clickedObject: { primitive: Primitive; id: Entity } = cesiumViewer.value.scene.pick(
-          movement.position,
-        );
-
-        router.push({ name: 'focus', params: { datasetId: clickedObject.id.name as string } });
-      }, ScreenSpaceEventType.LEFT_CLICK);
     });
 
     return {

--- a/client/src/components/DatasetPanel.vue
+++ b/client/src/components/DatasetPanel.vue
@@ -9,6 +9,7 @@
       :raster-ids="properties.rasters"
       :mesh-ids="properties.meshes"
       :tiles3d-ids="properties.tiles3d"
+      :fmv-ids="properties.fmvs"
     />
   </div>
 </template>

--- a/client/src/store/cesium/footprints.ts
+++ b/client/src/store/cesium/footprints.ts
@@ -1,32 +1,44 @@
 import { GeoJsonDataSource, HeadingPitchRange, Math } from 'cesium';
 import { ref, watch } from '@vue/composition-api';
 import { cesiumViewer, addGeojson } from '@/store/cesium';
-import { rgdImagery, rgdTiles3d } from '@/api';
 import { GeoJSON } from 'geojson';  // eslint-disable-line
 
 export const visibleFootprints = ref<Record<string, GeoJSON >>({});
 
-export const addFootprint = async (spatialId: number, imagery?: boolean) => {
-  let key;
-  let footprint;
-  if (imagery) {
-    footprint = (await rgdImagery(spatialId)).outline;
-    key = `imagery_${spatialId}`;
-  } else {
-    footprint = (await rgdTiles3d(spatialId)).outline;
-    key = `tiles3d_${spatialId}`;
+export const addFootprint = async (spatialId: number, footprint: GeoJSON|undefined, type: 'imagery' | 'tiles3d' | 'fmv') => {
+  let key: string;
+  switch (type) {
+    case 'imagery':
+      key = `imagery_${spatialId}`;
+      break;
+    case 'tiles3d':
+      key = `tiles3d_${spatialId}`;
+      break;
+    case 'fmv':
+      key = `fmv_${spatialId}`;
+      break;
+    default:
+      return;
   }
   if (key && footprint) {
     visibleFootprints.value = { ...visibleFootprints.value, [key]: footprint };
   }
 };
 
-export const removeFootprint = (spatialId: number, imagery?: boolean) => {
+export const removeFootprint = (spatialId: number, type: 'imagery' | 'tiles3d' | 'fmv') => {
   let key: string;
-  if (imagery) {
-    key = `imagery_${spatialId}`;
-  } else {
-    key = `tiles3d_${spatialId}`;
+  switch (type) {
+    case 'imagery':
+      key = `imagery_${spatialId}`;
+      break;
+    case 'tiles3d':
+      key = `tiles3d_${spatialId}`;
+      break;
+    case 'fmv':
+      key = `fmv_${spatialId}`;
+      break;
+    default:
+      return;
   }
   if (visibleFootprints.value[key]) {
     visibleFootprints.value = Object.fromEntries(

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-unresolved
-import type { GeoJSON } from 'geojson';
+import type { GeoJSON, MultiPoint, MultiPolygon } from 'geojson';
 
 export interface Paginated<T> {
   count: number;
@@ -98,4 +98,21 @@ export interface Tiles3D extends Model {
 export interface Tiles3DMeta extends SpatialEntry {
   source: Tiles3D;
   subentry_type: 'Tiles3DMeta';
+}
+
+export interface FMV extends Model {
+  file: ChecksumFile;
+  frame_rate: number;
+  klv_file: string;
+  web_video_file: string;
+}
+
+export interface FMVMeta extends SpatialEntry {
+  fmv_file: FMV;
+  frame_numbers: string;
+  flight_path: MultiPoint;
+  ground_frames: MultiPolygon;
+  ground_union: MultiPolygon;
+  instrumentation?: string;
+  subentry_type: 'FMVMeta';
 }

--- a/client/src/views/Explore.vue
+++ b/client/src/views/Explore.vue
@@ -22,9 +22,10 @@ import DatasetList from '@/components/DatasetList.vue';
 import CesiumViewer from '@/components/CesiumViewer.vue';
 import DatasetPanel from '@/components/DatasetPanel.vue';
 import { centroid } from '@turf/turf';
+import * as Cesium from 'cesium';
 import { Cartesian3 } from 'cesium';
 import { addPin } from '@/store/cesium/pins';
-import { addGeojson } from '@/store/cesium';
+import { addGeojson, cesiumViewer } from '@/store/cesium';
 import { Polygon } from 'geojson';  // eslint-disable-line
 
 export default defineComponent({
@@ -32,7 +33,7 @@ export default defineComponent({
   components: {
     DatasetList, CesiumViewer, DatasetPanel,
   },
-  setup() {
+  setup(props, ctx) {
     const footprints = ref({});
 
     onMounted(async () => {
@@ -46,6 +47,16 @@ export default defineComponent({
         addPin(Cartesian3.fromDegrees(x, y), datasetId); // add pin to dataset location to globe
         addGeojson(footprint, datasetId); // add dataset footprint to globe
       });
+
+      const handler = new Cesium.ScreenSpaceEventHandler(cesiumViewer.value.scene.canvas);
+      handler.setInputAction((movement: {position: Cesium.Cartesian2}) => {
+        const clickedObject: {
+          primitive: Cesium.Primitive; id: Cesium.Entity; } = cesiumViewer.value.scene.pick(
+            movement.position,
+          );
+
+        ctx.root.$router.push({ name: 'focus', params: { datasetId: clickedObject.id.name as string } });
+      }, Cesium.ScreenSpaceEventType.LEFT_CLICK);
     });
 
     return {

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ setup(
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',
-        'django-rgd[configuration]==0.3.3',
-        'django-rgd-3d==0.3.3',
-        'django-rgd-fmv==0.3.3',
-        'django-rgd-imagery==0.3.3',
+        'django-rgd==0.3.8',
+        'django-rgd-3d==0.3.8',
+        'django-rgd-fmv==0.3.8',
+        'django-rgd-imagery==0.3.8',
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',
@@ -56,7 +56,7 @@ setup(
         'django-s3-file-field[boto3]',
         'gunicorn',
         # Install with git
-        'RD-OASIS @ git+https://github.com/ResonantGeoData/RD-OASIS@531959cebf659070827d4c11c8a9f0e1db772470',  # noqa
+        'RD-OASIS @ git+https://github.com/ResonantGeoData/RD-OASIS@5b536ab3a9aa67a89c494a18beb3ce105c21779c',  # noqa
     ],
     dependency_links=['https://girder.github.io/large_image_wheels'],
     extras_require={


### PR DESCRIPTION
Depends on #47. 

This is the first part of #38; this PR adds support for viewing footprints and flight paths of FMV datasets on the existing CesiumJS viewer.

![fmv](https://user-images.githubusercontent.com/37340715/168891396-bca1eb6c-6f25-4a09-8e59-38c73607a46c.gif)

