### PR TITLE
Add video player + visualize FMV on Cesium map

### DIFF
--- a/client/src/components/CesiumViewer.vue
+++ b/client/src/components/CesiumViewer.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         // imageryProvider: false,
         imageryProviderViewModels: imageryViewModels,
         selectedImageryProviderViewModel: imageryViewModels[5], // Voyager
-        animation: false,
+        animation: true,
         shouldAnimate: true,
         timeline: true,
         infoBox: false,

--- a/client/src/components/FMVViewer.vue
+++ b/client/src/components/FMVViewer.vue
@@ -1,0 +1,102 @@
+<template>
+  <video
+    ref="videoElement"
+    width="100%"
+    height="240"
+    autobuffer
+    autoplay
+    crossorigin
+    loop
+  >
+    <source
+      :src="fmvMeta.fmv_file.web_video_file"
+      type="video/mp4; codecs=&quot;avc1.42E01E, mp4a.40.2&quot;"
+    >
+  </video>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent, onMounted, onUnmounted, PropType, ref,
+} from '@vue/composition-api';
+import * as Cesium from 'cesium';
+import { cesiumViewer } from '@/store/cesium';
+import { FMVMeta } from '@/types';
+
+export default defineComponent({
+  name: 'FMVViewer',
+  props: {
+    fmvMeta: {
+      type: Object as PropType<FMVMeta>,
+      required: true,
+    },
+  },
+  setup(props) {
+    const videoSynchronizer = ref<Cesium.VideoSynchronizer | null>(null);
+    const prevHierarchy = ref<Cesium.PolygonHierarchy | null>(null);
+    const polygonEntity = ref<Cesium.Entity | null>(null);
+    const videoElement = ref<HTMLVideoElement>();
+
+    onMounted(() => {
+      videoSynchronizer.value = new Cesium.VideoSynchronizer({
+        clock: cesiumViewer.value.clock,
+        element: videoElement.value,
+      });
+
+      polygonEntity.value = new Cesium.Entity({
+        polygon: new Cesium.PolygonGraphics({
+          hierarchy: new Cesium.CallbackProperty(() => {
+            if (!videoElement.value) {
+              return null;
+            }
+            const frameRate = props.fmvMeta.fmv_file.frame_rate;
+            const frameNumbers = props.fmvMeta.frame_numbers;
+            const groundFrames = props.fmvMeta.ground_frames;
+
+            const frame = Math.round(videoElement.value.currentTime * frameRate);
+            const index = frameNumbers.indexOf(frame);
+            if (index > -1) {
+              const coords = groundFrames.coordinates[index][0];
+
+              const newHierarchy = new Cesium.PolygonHierarchy([
+                Cesium.Cartesian3.fromDegrees(coords[0][0], coords[0][1]),
+                Cesium.Cartesian3.fromDegrees(coords[1][0], coords[1][1]),
+                Cesium.Cartesian3.fromDegrees(coords[2][0], coords[2][1]),
+                Cesium.Cartesian3.fromDegrees(coords[3][0], coords[3][1]),
+              ]);
+
+              prevHierarchy.value = newHierarchy;
+
+              return newHierarchy;
+            }
+            // If the no positional data exists for the current video frame,
+            // use the previous position. If we don't do this, this function
+            // will return `undefined`, which causes Cesium to render nothing
+            // for this frame, causing a flickering effect.
+            return prevHierarchy.value;
+          }, false),
+          material: Cesium.Color.RED,
+        }),
+      });
+
+      cesiumViewer.value.entities.add(polygonEntity.value);
+    });
+
+    onUnmounted(() => {
+      // Remove these entities from the Cesium map when the user stops the video -
+      if (videoSynchronizer.value && Cesium.defined(videoSynchronizer.value)) {
+        videoSynchronizer.value.destroy();
+        videoSynchronizer.value = null;
+      }
+      if (polygonEntity.value && Cesium.defined(polygonEntity.value)) {
+        cesiumViewer.value.entities.remove(polygonEntity.value);
+      }
+    });
+
+    return {
+      videoElement,
+    };
+  },
+});
+
+</script>

--- a/client/src/components/FileList.vue
+++ b/client/src/components/FileList.vue
@@ -1,101 +1,122 @@
 <template>
-  <v-simple-table v-if="!loading">
-    <template v-slot:default>
-      <thead>
-        <tr>
-          <th class="text-left">
-            File Name
-          </th>
-          <th class="text-left">
-            File Type
-          </th>
-          <th class="text-left">
-            Actions
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          v-for="tileset in tiles3d"
-          :key="tileset.spatial_id"
-        >
-          <td>{{ tileset.source.name }}</td>
-          <td>3D Tiles</td>
-          <td>
-            <v-btn
-              icon
-              @click="setTiles3dVisibility(tileset.spatial_id)"
-            >
-              <v-icon :color="tiles3dIsVisible(tileset.spatial_id) ? 'success' : ''">
-                mdi-eye
-              </v-icon>
-            </v-btn>
-          </td>
-        </tr>
-        <tr
-          v-for="raster in rasters"
-          :key="raster.spatial_id"
-        >
-          <td>{{ raster.parent_raster.name }}</td>
-          <td>Raster</td>
-          <td>
-            <v-btn
-              icon
-              @click="setRasterVisibility(raster.spatial_id)"
-            >
-              <v-icon :color="rasterIsVisible(raster.spatial_id) ? 'success' : ''">
-                mdi-eye
-              </v-icon>
-            </v-btn>
-          </td>
-        </tr>
-        <tr
-          v-for="fmv in Object.values(fmvs)"
-          :key="fmv.spatial_id"
-        >
-          <td
-            class="text-truncate"
-            style="max-width: 350px;"
+  <div>
+    <v-simple-table v-if="!loading">
+      <template v-slot:default>
+        <thead>
+          <tr>
+            <th class="text-left">
+              File Name
+            </th>
+            <th class="text-left">
+              File Type
+            </th>
+            <th class="text-left">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="tileset in tiles3d"
+            :key="tileset.spatial_id"
           >
-            {{ fmv.subentry_name }}
-          </td>
-          <td>FMV</td>
-          <td>
-            <v-btn
-              icon
-              @click="setFMVFootprintVisibility(fmv.spatial_id)"
-            >
-              <v-progress-circular
-                v-if="loading"
-                indeterminate
-              />
-              <v-icon
-                v-else
-                :color="fmvFootprintIsVisible(fmv.spatial_id) ? 'success' : ''"
+            <td>{{ tileset.source.name }}</td>
+            <td>3D Tiles</td>
+            <td>
+              <v-btn
+                icon
+                @click="setTiles3dVisibility(tileset.spatial_id)"
               >
-                mdi-foot-print
-              </v-icon>
-            </v-btn>
-            <v-btn
-              icon
-              @click="setFMVFlightPathVisibility(fmv.spatial_id)"
-            >
-              <v-progress-circular
-                v-if="loading"
-                indeterminate
-              />
-              <v-icon
-                v-else
-                :color="fmvFlightPathIsVisible(fmv.spatial_id) ? 'success' : ''"
+                <v-icon :color="tiles3dIsVisible(tileset.spatial_id) ? 'success' : ''">
+                  mdi-eye
+                </v-icon>
+              </v-btn>
+            </td>
+          </tr>
+          <tr
+            v-for="raster in rasters"
+            :key="raster.spatial_id"
+          >
+            <td>{{ raster.parent_raster.name }}</td>
+            <td>Raster</td>
+            <td>
+              <v-btn
+                icon
+                @click="setRasterVisibility(raster.spatial_id)"
               >
-                mdi-airplane
-              </v-icon>
-            </v-btn>
-          </td>
-        </tr>
-      </tbody>
-    </template>
-  </v-simple-table>
+                <v-icon :color="rasterIsVisible(raster.spatial_id) ? 'success' : ''">
+                  mdi-eye
+                </v-icon>
+              </v-btn>
+            </td>
+          </tr>
+          <tr
+            v-for="fmv in Object.values(fmvs)"
+            :key="fmv.spatial_id"
+          >
+            <td
+              class="text-truncate"
+              style="max-width: 350px;"
+            >
+              {{ fmv.subentry_name }}
+            </td>
+            <td>FMV</td>
+            <td>
+              <v-btn
+                icon
+                @click="setFMVFootprintVisibility(fmv.spatial_id)"
+              >
+                <v-progress-circular
+                  v-if="loading"
+                  indeterminate
+                />
+                <v-icon
+                  v-else
+                  :color="fmvFootprintIsVisible(fmv.spatial_id) ? 'success' : ''"
+                >
+                  mdi-foot-print
+                </v-icon>
+              </v-btn>
+              <v-btn
+                icon
+                @click="setFMVFlightPathVisibility(fmv.spatial_id)"
+              >
+                <v-progress-circular
+                  v-if="loading"
+                  indeterminate
+                />
+                <v-icon
+                  v-else
+                  :color="fmvFlightPathIsVisible(fmv.spatial_id) ? 'success' : ''"
+                >
+                  mdi-airplane
+                </v-icon>
+              </v-btn>
+              <v-btn
+                icon
+                @click="setVideoSrc(fmv.spatial_id)"
+              >
+                <v-progress-circular
+                  v-if="loading"
+                  indeterminate
+                />
+                <v-icon
+                  v-else
+                  :color="fmvBeingViewed ? 'success' : ''"
+                >
+                  mdi-eye
+                </v-icon>
+              </v-btn>
+            </td>
+          </tr>
+        </tbody>
+      </template>
+    </v-simple-table>
+    <FMVViewer
+      v-if="fmvBeingViewed"
+      :fmv-meta="fmvBeingViewed"
+    />
+  </div>
 </template>
 
 <script lang="ts">
@@ -109,9 +130,11 @@ import * as Cesium from 'cesium';
 import { addFootprint, removeFootprint, visibleFootprints } from '@/store/cesium/footprints';
 import { FMVMeta, RasterMeta, Tiles3DMeta } from '@/types';
 import { renderFlightPath } from '@/utils/cesium';
+import FMVViewer from './FMVViewer.vue';
 
 export default defineComponent({
   name: 'FileList',
+  components: { FMVViewer },
   props: {
     datasetId: {
       type: String,
@@ -138,6 +161,8 @@ export default defineComponent({
     const rasters = ref<RasterMeta[]>([]);
     const tiles3d = ref<Tiles3DMeta[]>([]);
     const fmvs = ref<Record<number, FMVMeta>>({});
+
+    const fmvBeingViewed = ref<FMVMeta | null>(null);
 
     const loading = ref(true);
 
@@ -189,6 +214,14 @@ export default defineComponent({
       });
       cesiumViewer.value.scene.primitives.add(tileset);
       addFootprint(current.spatial_id, current.footprint, 'tiles3d');
+    }
+
+    function setVideoSrc(fmvId: number) {
+      if (!fmvBeingViewed.value) {
+        fmvBeingViewed.value = fmvs.value[fmvId];
+      } else {
+        fmvBeingViewed.value = null;
+      }
     }
 
     function fmvFootprintIsVisible(fmvId: number) {
@@ -288,10 +321,12 @@ export default defineComponent({
       rasters,
       tiles3d,
       fmvs,
+      fmvBeingViewed,
       setRasterVisibility,
       setTiles3dVisibility,
       setFMVFootprintVisibility,
       setFMVFlightPathVisibility,
+      setVideoSrc,
       fmvFootprintIsVisible,
       fmvFlightPathIsVisible,
       tiles3dIsVisible,

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -109,7 +109,7 @@ export interface FMV extends Model {
 
 export interface FMVMeta extends SpatialEntry {
   fmv_file: FMV;
-  frame_numbers: string;
+  frame_numbers: number[];
   flight_path: MultiPoint;
   ground_frames: MultiPolygon;
   ground_union: MultiPolygon;

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ setup(
         'django-extensions',
         'django-filter',
         'django-oauth-toolkit',
-        'django-rgd==0.3.8',
-        'django-rgd-3d==0.3.8',
-        'django-rgd-fmv==0.3.8',
-        'django-rgd-imagery==0.3.8',
+        'django-rgd @ git+https://github.com/ResonantGeoData/ResonantGeoData@main#subdirectory=django-rgd',  # noqa
+        'django-rgd-3d @ git+https://github.com/ResonantGeoData/ResonantGeoData@main#subdirectory=django-rgd-3d',  # noqa
+        'django-rgd-fmv @ git+https://github.com/ResonantGeoData/ResonantGeoData@main#subdirectory=django-rgd-fmv',  # noqa
+        'django-rgd-imagery @ git+https://github.com/ResonantGeoData/ResonantGeoData@main#subdirectory=django-rgd-imagery',  # noqa
         'djangorestframework',
         'drf-extensions',
         'drf-yasg',


### PR DESCRIPTION
Closes #38. This is blocked on https://github.com/ResonantGeoData/ResonantGeoData/pull/757 and https://github.com/ResonantGeoData/ResonantGeoData/pull/759.

This PR essentially replicates the functionality that the `rgd_fmv` module's SSR pages currently have, except in Cesium instead of GeoJS, i.e. it displays the FMV video on the side in a `<video>` element, while rendering the animated geospatial footprint from the FMV on the map as a polygon. For reference, original SSR code is here https://github.com/ResonantGeoData/ResonantGeoData/blob/main/django-rgd-fmv/rgd_fmv/templates/rgd_fmv/fmvmeta_detail.html

![fmv2](https://user-images.githubusercontent.com/37340715/169922454-3f3046be-be3f-4e1b-99e2-937d14facc5b.gif)

