### PR TITLE
Update README instructions for running celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the simplest configuration for developers to start with.
 1. Run `docker-compose run --rm django ./manage.py migrate`
 2. Run `docker-compose run --rm django ./manage.py createsuperuser`
    and follow the prompts to create your own user
-3. Create a virtual environment and run `pip install -e .[worker]` inside of it.
+3. Create a virtual environment and run `pip install --find-links https://girder.github.io/large_image_wheels -e .[worker]` inside of it.
 
 ### Run Application
 **Note**: Even though most of the application will be run with `docker-compose`, the `celery` worker must still be run natively, as it itself makes use of `docker`.


### PR DESCRIPTION
Adds `--find-links https://girder.github.io/large_image_wheels` to the `pip install` step for the celery worker.