### PR TITLE
Filter input/output datasets

### DIFF
--- a/client/src/components/DatasetList.vue
+++ b/client/src/components/DatasetList.vue
@@ -31,7 +31,8 @@ export default defineComponent({
   setup() {
     const datasets = ref([]);
 
-    axiosInstance.get('/datasets/')
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    axiosInstance.get('/datasets/', { params: { include_input_datasets: false } })
       .then((resp: AxiosResponse) => {
         datasets.value = resp.data.results;
       });

--- a/client/src/views/AlgorithmView.vue
+++ b/client/src/views/AlgorithmView.vue
@@ -71,7 +71,8 @@ export default defineComponent({
       fetchingDatasetList.value = true;
 
       try {
-        const res = await axiosInstance.get('datasets/');
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        const res = await axiosInstance.get('datasets/', { params: { include_output_datasets: false } });
         datasetList.value = res.data.results;
       } catch (error) {
         // TODO: Handle

--- a/danesfield/core/views/dataset.py
+++ b/danesfield/core/views/dataset.py
@@ -1,9 +1,10 @@
 import json
 
 from django.contrib.gis.geos import MultiPoint, Point
+from django.db.models import Exists, OuterRef
 from django.http import JsonResponse
 from django.shortcuts import redirect
-from rdoasis.algorithms.models import Dataset
+from rdoasis.algorithms.models import AlgorithmTask, Dataset
 from rdoasis.algorithms.views.algorithms import DatasetViewSet as BaseDatasetViewSet
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -13,8 +14,25 @@ from rgd_3d.models import Mesh3D, Mesh3DSpatial, Tiles3DMeta
 from rgd_fmv.models import FMVMeta
 from rgd_imagery.models import RasterMeta
 
+from danesfield.core.views.serializers import DatasetListQueryParamsSerializer
+
 
 class DatasetViewSet(BaseDatasetViewSet):
+    def get_queryset(self):
+        qs = super().get_queryset()
+        if self.action == 'list':
+            query_serializer = DatasetListQueryParamsSerializer(data=self.request.query_params)
+            query_serializer.is_valid(raise_exception=True)
+
+            include_input_datasets: bool = query_serializer.validated_data['include_input_datasets']
+
+            if not include_input_datasets:
+                qs = qs.annotate(
+                    is_input=Exists(AlgorithmTask.objects.filter(input_dataset=OuterRef('pk')))
+                ).filter(is_input=False)
+
+        return qs
+
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
         serializer = self.get_serializer(instance)

--- a/danesfield/core/views/dataset.py
+++ b/danesfield/core/views/dataset.py
@@ -25,11 +25,19 @@ class DatasetViewSet(BaseDatasetViewSet):
             query_serializer.is_valid(raise_exception=True)
 
             include_input_datasets: bool = query_serializer.validated_data['include_input_datasets']
+            include_output_datasets: bool = query_serializer.validated_data[
+                'include_output_datasets'
+            ]
 
             if not include_input_datasets:
                 qs = qs.annotate(
                     is_input=Exists(AlgorithmTask.objects.filter(input_dataset=OuterRef('pk')))
                 ).filter(is_input=False)
+
+            if not include_output_datasets:
+                qs = qs.annotate(
+                    is_output=Exists(AlgorithmTask.objects.filter(output_dataset=OuterRef('pk')))
+                ).filter(is_output=False)
 
         return qs
 

--- a/danesfield/core/views/serializers.py
+++ b/danesfield/core/views/serializers.py
@@ -3,8 +3,8 @@ from rest_framework import serializers
 
 class DatasetListQueryParamsSerializer(serializers.Serializer):
     include_input_datasets = serializers.BooleanField(
-        default=True, help_text='Whether or not to include input datasets.'
+        default=True, help_text='Whether or not to include input datasets in response.'
     )
     include_output_datasets = serializers.BooleanField(
-        default=True, help_text='Whether or not to include input datasets.'
+        default=True, help_text='Whether or not to include output datasets in response.'
     )

--- a/danesfield/core/views/serializers.py
+++ b/danesfield/core/views/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+
+
+class DatasetListQueryParamsSerializer(serializers.Serializer):
+    include_input_datasets = serializers.BooleanField(
+        default=True, help_text='Whether or not to include input datasets.'
+    )

--- a/danesfield/core/views/serializers.py
+++ b/danesfield/core/views/serializers.py
@@ -5,3 +5,6 @@ class DatasetListQueryParamsSerializer(serializers.Serializer):
     include_input_datasets = serializers.BooleanField(
         default=True, help_text='Whether or not to include input datasets.'
     )
+    include_output_datasets = serializers.BooleanField(
+        default=True, help_text='Whether or not to include input datasets.'
+    )


### PR DESCRIPTION
Adds new query parameters to the dataset endpoint for filtering input and output datasets, and uses it in the frontend on the explore tab and tasks tab. 

Closes #60 