### PR TITLE
Display `ground_union` instead of `footprint` for FMVs

### DIFF
--- a/client/src/components/FileList.vue
+++ b/client/src/components/FileList.vue
@@ -234,7 +234,7 @@ export default defineComponent({
         // If the footprint is already visible, make it invisible
         removeFootprint(fmvId, 'fmv');
       } else {
-        addFootprint(fmvId, fmvs.value[fmvId].footprint, 'fmv');
+        addFootprint(fmvId, fmvs.value[fmvId].ground_union, 'fmv');
       }
 
       loading.value = false;


### PR DESCRIPTION
Fixes #69 